### PR TITLE
optimize writing of static text to client

### DIFF
--- a/nope.c
+++ b/nope.c
@@ -50,24 +50,14 @@ char *default_mime_type = "text/plain";
 /**********************************************************************/
 void unimplemented(int client)
 {
-	char buf[1024];
-
-	sprintf(buf, "HTTP/1.0 501 Method Not Implemented\r\n");
-	send(client, buf, strlen(buf), 0);
-	sprintf(buf, SERVER_STRING);
-	send(client, buf, strlen(buf), 0);
-	sprintf(buf, "Content-Type: text/html\r\n");
-	send(client, buf, strlen(buf), 0);
-	sprintf(buf, "\r\n");
-	send(client, buf, strlen(buf), 0);
-	sprintf(buf, "<HTML><HEAD><TITLE>Method Not Implemented\r\n");
-	send(client, buf, strlen(buf), 0);
-	sprintf(buf, "</TITLE></HEAD>\r\n");
-	send(client, buf, strlen(buf), 0);
-	sprintf(buf, "<BODY><P>HTTP request method not supported.\r\n");
-	send(client, buf, strlen(buf), 0);
-	sprintf(buf, "</BODY></HTML>\r\n");
-	send(client, buf, strlen(buf), 0);
+	STATIC_SEND(client, "HTTP/1.0 501 Method Not Implemented\r\n", 0);
+	STATIC_SEND(client, SERVER_STRING, 0);
+	STATIC_SEND(client, "Content-Type: text/html\r\n", 0);
+	STATIC_SEND(client, "\r\n", 0);
+	STATIC_SEND(client, "<HTML><HEAD><TITLE>Method Not Implemented\r\n", 0);
+	STATIC_SEND(client, "</TITLE></HEAD>\r\n", 0);
+	STATIC_SEND(client, "<BODY><P>HTTP request method not supported.\r\n", 0);
+	STATIC_SEND(client, "</BODY></HTML>\r\n", 0);
 }
 
 void rio_readinitb(rio_t *rp, int fd){

--- a/nopeutils.c
+++ b/nopeutils.c
@@ -185,14 +185,10 @@ void writeStandardHeaders(int client)
 {
 	char buf[MAX_BUFFER_SIZE];
 
-	strcpy(buf, "HTTP/1.0 200 OK\r\n");
-	send(client, buf, strlen(buf), 0);
-	strcpy(buf, SERVER_STRING);
-	send(client, buf, strlen(buf), 0);
-	strcpy(buf, "Content-Type: text/html\r\n");
-	send(client, buf, strlen(buf), 0);
-	strcpy(buf, "\r\n");
-	send(client, buf, strlen(buf), 0);
+	STATIC_SEND(client, "HTTP/1.0 200 OK\r\n", 0);
+	STATIC_SEND(client, SERVER_STRING, 0);
+	STATIC_SEND(client, "Content-Type: text/html\r\n", 0);
+	STATIC_SEND(client, "\r\n", 0);
 }
 
 void cat(int client, FILE *pFile)
@@ -213,22 +209,18 @@ void serveDownloadableFile(int client, const char *filename, const char *display
 
 	FILE *resource = NULL;
 	char buf[1024];
+	size_t len;
 
-	strcpy(buf, "HTTP/1.0 200 OK\r\n");
-	send(client, buf, strlen(buf), 0);
+	STATIC_SEND(client, "HTTP/1.0 200 OK\r\n", 0);
+	STATIC_SEND(client, SERVER_STRING, 0);
 
-	strcpy(buf, SERVER_STRING);
-	send(client, buf, strlen(buf), 0);
+	len = snprintf(buf, sizeof(buf), "Content-Type: %s\r\n",type);
+	send(client, buf, len, 0);
 
-	sprintf(buf, "Content-Type: %s\r\n",type);
-	send(client, buf, strlen(buf), 0);
-	strcpy(buf, "\r\n");
+	len = snprintf(buf, sizeof(buf), "Content-Disposition: attachment; filename=\"%s\"\r\n",displayFilename);
+	send(client, buf, len, 0);
 
-	sprintf(buf, "Content-Disposition: attachment; filename=\"%s\"\r\n",displayFilename);
-	send(client, buf, strlen(buf), 0);
-	strcpy(buf, "\r\n");
-
-	send(client, buf, strlen(buf), 0);
+	STATIC_SEND(client, "\r\n", 0);
 
 	resource = fopen(filename, "r");
 	if (resource == NULL)
@@ -246,18 +238,15 @@ void serveFile(int client, const char *filename, const char * type)
 
 	FILE *resource = NULL;
 	char buf[1024];
+	size_t len;
 
-	strcpy(buf, "HTTP/1.0 200 OK\r\n");
-	send(client, buf, strlen(buf), 0);
+	STATIC_SEND(client, "HTTP/1.0 200 OK\r\n", 0);
+	STATIC_SEND(client, SERVER_STRING, 0);
 
-	strcpy(buf, SERVER_STRING);
-	send(client, buf, strlen(buf), 0);
+	len = snprintf(buf, sizeof(buf), "Content-Type: %s\r\n",type);
+	send(client, buf, len, 0);
 
-	sprintf(buf, "Content-Type: %s\r\n",type);
-	send(client, buf, strlen(buf), 0);
-	strcpy(buf, "\r\n");
-
-	send(client, buf, strlen(buf), 0);
+	STATIC_SEND(client, "\r\n", 0);
 
 	resource = fopen(filename, "r");
 	if (resource == NULL)

--- a/nopeutils.h
+++ b/nopeutils.h
@@ -43,6 +43,8 @@
 
 #define HP_CLOSE CRLF CTAG(body) CRLF CTAG(html)
 
+#define STATIC_SEND(_socket, _str, _flags) send(_socket, _str, sizeof(_str)-1, _flags)
+
 #include <stdarg.h>
 char ** readHeaders(int);
 void freeHeaders(char **);


### PR DESCRIPTION
When sending fixed text to client rather than using sprintf/strlen, it is possible to optimize this by having the compiler compute the appropriate length.

Using sizeof(_string) would return length of string plus 1 (the final \0) - so we use sizeof(_str)-1.

Makes the code easier to read and removes the need to use an intermediate buffer.
