### PR TITLE
improved makefile, fixed some warnings and removed linking on pthread (unused)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,27 @@
-all: server
+#!/bin/make
 
-server: nope.c
-	gcc -W -Wall -pthread -o server nopeutils.c nope.c server.c
+CC=gcc
+AR=ar
+CFLAGS=-W -Wall -O2
+LIBNOPE_OBJ=nope.o nopeutils.o
+LIBNOPE=libnope.a
+MODULES=server
+
+all: $(MODULES)
+
+# rule to build modules
+%: %.c $(LIBNOPE)
+	$(CC) $(CFLAGS) -o $@ $^
+
+$(LIBNOPE): $(LIBNOPE_OBJ)
+	$(AR) r $@ $^
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
 
 clean:
-	rm server
+	rm $(LIBNOPE_OBJ)
+
+distclean:
+	rm $(LIBNOPE) $(LIBNOPE_OBJ) $(MODULES)
+

--- a/nopeutils.c
+++ b/nopeutils.c
@@ -14,7 +14,6 @@
 #include <strings.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <pthread.h>
 #include <sys/wait.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -156,7 +155,7 @@ char ** readHeaders(int client) {
 		/* printf("Numchars %d %s\n",numchars,buf); */
 		headers[i]=malloc((numchars+1)*sizeof(char));
 		memcpy(headers[i],buf,numchars);
-		headers[i][numchars]=NULL;
+		headers[i][numchars]=0;
 		i++;
 		numchars = getLine(client, buf, sizeof(buf));
 	}
@@ -183,8 +182,6 @@ char * getHeader(char **headers, char *header) {
 
 void writeStandardHeaders(int client)
 {
-	char buf[MAX_BUFFER_SIZE];
-
 	STATIC_SEND(client, "HTTP/1.0 200 OK\r\n", 0);
 	STATIC_SEND(client, SERVER_STRING, 0);
 	STATIC_SEND(client, "Content-Type: text/html\r\n", 0);


### PR DESCRIPTION
Made makefile look slightly better, building nope.c as a static library (libnope.a), and added the ability to have multiple samples (variable "MODULES" in the makefile) compiled.
Additionally if you develop your own module (ex. foobar.c) in nope.c's main directory, you can then type "make foobar" to get your source compiled against nope.c.

Also removed -pthread parameter since only fork() is being used (ie. no threads right now).

Finally fixed some warnings in nope.c and nopeutils.c 
