### PR TITLE
Added loop to find first occurence of actual string to solve abc=1&bc=2 ...

### DIFF
--- a/nopeutils.c
+++ b/nopeutils.c
@@ -29,11 +29,17 @@
 
 char * getQueryParam(const char * queryString, const char *name) { 
 
-	/* Todo: Will break on abc=1&bc=1. fix */
-
 	char *pos1 = strstr(queryString, name);
 	char *value = malloc(MAX_BUFFER_SIZE*sizeof(char));
 	int i;
+
+    int queryStringPos = pos1-queryString;
+    char *pos2 = pos1;
+    while (queryStringPos > 0 && queryString[queryStringPos-1] != '&') {
+        pos1 = strstr(pos2, name);
+        queryStringPos += pos2-pos1;
+        pos2 += strlen(name);
+    }
 
 	if (pos1) {
 		pos1 += strlen(name);


### PR DESCRIPTION
Used a simple loop to find the first actual occurrence of a string. This prevents the function from resolving a substring as a full query parameter. I make sure that the parameter found is either the first char in the original queryString or that it is preceded by an '&' character. This should be sufficient.
