### PR TITLE
Avoid buffer overflow with strncpy.

### DIFF
--- a/nope.c
+++ b/nope.c
@@ -266,7 +266,7 @@ void process(int fd,  fd_set *pMaster, struct sockaddr_in *clientaddr){
 	close(client);
 
 	http_request req;
-	strcpy(req.filename,url);
+	strncpy(req.filename, url, sizeof req.filename);
     log_access(status, clientaddr, &req);
 }
 


### PR DESCRIPTION
As mentioned in #3 the size of req.filename is 512 and url is twice the size. Strncpy is the better choice here.
