### PR TITLE
Fix double close bug when using serveFile api

### DIFF
--- a/nopeapi.c
+++ b/nopeapi.c
@@ -310,7 +310,6 @@ static void sendFileWithSelect(int write_fd, int read_fd, struct stat stat_buf)
 
      /* Close up. */
      close (read_fd);
-     close (write_fd);
 }
 
 ssize_t writeLongString(int client, const char *longString, size_t len)


### PR DESCRIPTION
Wrote a small service to serve static content using this method. Closing the write handle here leads to double close bugs later on. It's unnecessary given the wrapping framework.
